### PR TITLE
Use SSL with Twitter

### DIFF
--- a/src/qarth/impl/twitter.clj
+++ b/src/qarth/impl/twitter.clj
@@ -6,7 +6,7 @@
            cheshire.core))
 
 (qarth.impl.scribe/extend-scribe :twitter :scribe-v1
-                                 org.scribe.builder.api.TwitterApi)
+                                 org.scribe.builder.api.TwitterApi$SSL)
 (qarth.impl.scribe/extend-scribe :twitter-login :twitter
                                  org.scribe.builder.api.TwitterApi$Authenticate)
 


### PR DESCRIPTION
Using the Twitter API with the current (0.1.0) version of qarth results in the following exception:

```
org.scribe.exceptions.OAuthException: Response body is incorrect. Can't extract token and secret from this: 'SSL is required'
    at org.scribe.extractors.TokenExtractorImpl.extract(TokenExtractorImpl.java:41)
    at org.scribe.extractors.TokenExtractorImpl.extract(TokenExtractorImpl.java:27)
    at org.scribe.oauth.OAuth10aServiceImpl.getRequestToken(OAuth10aServiceImpl.java:64)
    at org.scribe.oauth.OAuth10aServiceImpl.getRequestToken(OAuth10aServiceImpl.java:40)
    at org.scribe.oauth.OAuth10aServiceImpl.getRequestToken(OAuth10aServiceImpl.java:45)
    at qarth.impl.scribe$eval4976$fn__4978.invoke(scribe.clj:76)
```

The Twitter API does not support non-SSL login anymore. In the master branch of Scribe, SSL is the default, but in 1.3.5 (which is the latest published release), it has to be explicitly selected.

Pending this PR, if anyone experiences the same problem, it can be solved by adding:

``` clojure
(qarth.impl.scribe/extend-scribe :twitter :scribe-v1
                                 org.scribe.builder.api.TwitterApi$SSL)
```

somewhere before calling in the qarth machinery (specifically, before the call to `qarth.oauth/build`).
