### PR TITLE
Clj 1.9 support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject qarth "0.1.3"
+(defproject qarth "0.2.0"
   :description "OAuth for serious people"
   :url "https://github.com/mthvedt/qarth"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
   :aliases {"example" ["trampoline" "with-profile" "example" "run" "-m"]
             "exdebug" ["trampoline" "with-profile" "example,debug" "run" "-m"]}
   :deploy-repositories [["clojars" {:creds :gpg}]]
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
 
                  [org.clojure/data.codec "0.1.0"]
                  [crypto-random "1.2.0"]

--- a/src/qarth/core.clj
+++ b/src/qarth/core.clj
@@ -1,7 +1,7 @@
 (ns qarth.core
   "Core NS for Qarth. Right now this is just some support
   for qarth.oauth and implementations."
-  (use slingshot.slingshot))
+  (:use slingshot.slingshot))
 
 (defn unauthorized
   "Throw an unauthorized Slingshot exception.

--- a/src/qarth/friend.clj
+++ b/src/qarth/friend.clj
@@ -1,10 +1,11 @@
 (ns qarth.friend
   "Friend workflows for Qarth."
-  (require (qarth [oauth :as oauth]
-                  [ring :as qarth-ring])
-           [cemerick.friend :as friend]
-           (ring.util request response)
-           [clojure.tools.logging :as log]))
+  (:require [qarth.oauth :as oauth]
+            [qarth.ring :as qarth-ring]
+            [cemerick.friend :as friend]
+            [ring.util.request]
+            [ring.util.response]
+            [clojure.tools.logging :as log]))
 
 (defn- credential-map
   ;Adds Friend meta-information to the auth record, and uses that
@@ -12,20 +13,20 @@
   [credential-fn record redirect-on-auth?]
   (if-let [r (credential-fn record)]
     (vary-meta r assoc
-               ::friend/workflow ::qarth
-               ::friend/redirect-on-auth? redirect-on-auth?
-               :type ::friend/auth)))
+               :cemerick.friend/workflow ::qarth
+               :cemerick.friend/redirect-on-auth? redirect-on-auth?
+               :type :cemerick.friend/auth)))
 
 (defn auth-record
   "Looks for a qarth auth record in the Friend authentications.
   Returns it, or nil if not found."
   [req]
   (->> req
-    :session ::friend/identity :authentications
+    :session :cemerick.friend/identity :authentications
     vals
-    (filter #(-> % meta ::friend/workflow (= ::qarth)))
+    (filter #(-> % meta :cemerick.friend/workflow (= ::qarth)))
     first
-    ::oauth/record))
+    :qarth.oauth/record))
 
 (defn requestor
   "Get an auth requestor from a Friend-authenticated request and a service."
@@ -50,7 +51,7 @@
   credential-fn -- override the Friend credential fn.
   The default Friend credential-fn, for some reason, returns nil.
   The credential map supplied is of the form
-  {::qarth.oauth/record auth-record, :identity ::qarth.oauth/anonymous}.
+  {:qarth.oauth/record auth-record, :identity :qarth.oauth/anonymous}.
   redirect-on-auth? -- the Friend redirect on auth setting, default true
   login-failure-handler -- the login failure handler.
   The default is to redirect to the configured login-url.
@@ -60,7 +61,7 @@
   [{:keys [service key auth-url credential-fn redirect-on-auth?
            login-url login-uri login-failure-handler] :as params}]
   (fn [{ring-sesh :session :as req}]
-    (let [auth-config (merge (::friend/auth-config req) params)
+    (let [auth-config (merge (:cemerick.friend/auth-config req) params)
           auth-url (or auth-url (:auth-url auth-config))]
       (if (= (ring.util.request/path-info req) auth-url)
         (let [
@@ -68,10 +69,10 @@
               redirect-on-auth? (or redirect-on-auth?
                                     (:redirect-on-auth? auth-config) true)
               credential-fn (or credential-fn (:credential-fn auth-config))
-              success-handler (fn [{{record ::oauth/record} :session}]
+              success-handler (fn [{{record :qarth.oauth/record} :session}]
                                 (credential-map credential-fn
-                                                {::oauth/record record
-                                                 :identity ::qarth.oauth/anonymous}
+                                                {:qarth.oauth/record record
+                                                 :identity :qarth.oauth/anonymous}
                                                 redirect-on-auth?))
               login-failure-handler (or login-failure-handler
                                         (get auth-config :login-failure-handler)

--- a/src/qarth/impl/facebook.clj
+++ b/src/qarth/impl/facebook.clj
@@ -1,6 +1,6 @@
 (ns qarth.impl.facebook
   "A Facebook oauth impl. Type is :facebook."
-  (require (qarth [oauth :as oauth])
+  (:require (qarth [oauth :as oauth])
            [qarth.oauth.lib :as lib]
            qarth.impl.oauth-v2
            cheshire.core))

--- a/src/qarth/impl/github.clj
+++ b/src/qarth/impl/github.clj
@@ -1,6 +1,6 @@
 (ns qarth.impl.github
   "A Github oauth impl. Type is :github."
-  (require (qarth [oauth :as oauth])
+  (:require (qarth [oauth :as oauth])
            qarth.impl.oauth-v2
            cheshire.core))
 

--- a/src/qarth/impl/google.clj
+++ b/src/qarth/impl/google.clj
@@ -1,7 +1,7 @@
 (ns qarth.impl.google
   "A Google oauth impl. Type is :google.
   Default OAuth scope is \"openid email\" (Google requires an OAuth scope)."
-  (require (qarth [oauth :as oauth])
+  (:require (qarth [oauth :as oauth])
            [qarth.oauth.lib :as lib]
            qarth.impl.oauth-v2
            cheshire.core

--- a/src/qarth/impl/oauth_v2.clj
+++ b/src/qarth/impl/oauth_v2.clj
@@ -1,7 +1,7 @@
 (ns qarth.impl.oauth-v2
   "A generic OAuth v2 implementation. Services should have the keys
   :request-url and :access-url. Assumes form-encoded responses."
-  (require (qarth [oauth :as oauth] core)
+  (:require (qarth [oauth :as oauth] core)
            [qarth.oauth.lib :as lib]
            clj-http.client))
 

--- a/src/qarth/impl/scribe.clj
+++ b/src/qarth/impl/scribe.clj
@@ -2,13 +2,13 @@
   "An implementation of OAuth for Scribe, with type :scribe.
   The build method requires a Scribe OAuth provider class, under the key
   :provider."
-  (require (qarth [oauth :as oauth]
+  (:require (qarth [oauth :as oauth]
                   [util :as util])
            [qarth.oauth.lib :as lib]
            clojure.java.io
            clojure.string
            [clojure.tools.logging :as log])
-  (import [java.lang String Boolean]
+  (:import [java.lang String Boolean]
           [org.scribe.model OAuthRequest Token]
           [org.scribe.oauth OAuthService]))
 

--- a/src/qarth/impl/twitter.clj
+++ b/src/qarth/impl/twitter.clj
@@ -1,6 +1,6 @@
 (ns qarth.impl.twitter
   "A Twitter oauth impl. Type is :twitter."
-  (require (qarth [oauth :as oauth])
+  (:require (qarth [oauth :as oauth])
            [qarth.oauth.lib :as lib]
            qarth.impl.scribe
            cheshire.core))

--- a/src/qarth/impl/yahoo.clj
+++ b/src/qarth/impl/yahoo.clj
@@ -1,6 +1,6 @@
 (ns qarth.impl.yahoo
   "Implementation for Yahoo! The type is :yahoo."
-  (require [qarth.oauth :as oauth]
+  (:require [qarth.oauth :as oauth]
            [qarth.oauth.lib :as lib]
            qarth.impl.scribe
            clojure.data.xml))

--- a/src/qarth/impls.clj
+++ b/src/qarth/impls.clj
@@ -1,3 +1,3 @@
 (ns qarth.impls
   "Namespace that requires all methods bundled with Qarth."
-  (require (qarth.impl yahoo github google facebook twitter)))
+  (:require (qarth.impl yahoo github google facebook twitter)))

--- a/src/qarth/oauth.clj
+++ b/src/qarth/oauth.clj
@@ -1,7 +1,7 @@
 (ns qarth.oauth
   "Base fns for OAuth and OAuth-style interactive auth services.
   You can also define your own auth implementations--see the docs."
-  (require [qarth.support :as s]
+  (:require [qarth.support :as s]
            [qarth.oauth.lib :as lib])
   (:refer-clojure :exclude [derive]))
 

--- a/src/qarth/oauth/lib.clj
+++ b/src/qarth/oauth/lib.clj
@@ -1,6 +1,6 @@
 (ns qarth.oauth.lib
   "Helper fns for OAuth implementations."
-  (require (qarth [core :as core])
+  (:require (qarth [core :as core])
            clj-http.client
            cheshire.core
            ring.util.codec

--- a/src/qarth/ring.clj
+++ b/src/qarth/ring.clj
@@ -2,7 +2,7 @@
   "Low-level Ring fns to use with Qarth.
   This lib is in a state of flux,
   so you probably shouldn't refer to it in your code."
-  (require (qarth [oauth :as oauth] [core :as core])
+  (:require (qarth [oauth :as oauth] [core :as core])
            ring.util.response
            [clojure.tools.logging :as log])
   (:refer-clojure :exclude [get set update]))

--- a/src/qarth/support.clj
+++ b/src/qarth/support.clj
@@ -1,6 +1,6 @@
 (ns qarth.support
   "Support fns for qarth, for implementing or extending behavior."
-  (require crypto.random))
+  (:require crypto.random))
 
 (def ^{:doc "The OAuth hierarchy ref."}
   h

--- a/src/qarth/util.clj
+++ b/src/qarth/util.clj
@@ -1,6 +1,6 @@
 (ns qarth.util
   "Some utility fns that are not important parts of Qarth, but you may find useful."
-  (require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]))
 
 (defn read-resource
   "Reads the resource identified by the given name, with read-eval set to false.


### PR DESCRIPTION
clj 1.9 is having trouble working with this lib due to no support for ::namespace/keywords, and a strict classpath that requires :require as keywords.

This gets things to a compiling, somewhat runnable state. Version bumping due to the fact that this might break things.